### PR TITLE
Add a debug console

### DIFF
--- a/class/bejeweled.ts
+++ b/class/bejeweled.ts
@@ -309,7 +309,7 @@ class Bejeweled {
   }
 
   loadBoard(useSampleData: boolean) {
-    const sampleGrid = parseSampleData();
+    const sampleGrid = useSampleData ? parseSampleData() : [];
     for (let col = 0; col < this.grid.length; col++) {
       for (let row = 0; row < this.grid.length; row++) {
         this.grid[row][col] = useSampleData

--- a/class/bejeweled.ts
+++ b/class/bejeweled.ts
@@ -317,6 +317,7 @@ class Bejeweled {
           : this.fruit[Math.floor(Math.random() * this.fruit.length)];
       }
     }
+    this.screen.debugConsole.logInfo("Initialized grid");
     this.screen.render();
   }
 }

--- a/class/console.ts
+++ b/class/console.ts
@@ -1,0 +1,114 @@
+type Verbosity = "debug" | "info";
+
+interface LogLine {
+  time: Date;
+  message: string;
+  verbosity: Verbosity;
+}
+
+interface Box {
+  corners: {
+    topLeft: string;
+    topRight: string;
+    bottomLeft: string;
+    bottomRight: string;
+  };
+  vertical: string;
+  horizontal: string;
+
+  beginText: string;
+  endText: string;
+}
+
+const combiningOverline = "\u0305";
+const combiningUnderline = "\u0332";
+
+const doubleLineBox: Box = {
+  corners: {
+    topLeft: "\u2554",
+    topRight: "\u2557",
+    bottomLeft: "\u255A",
+    bottomRight: "\u255D",
+  },
+  vertical: "\u2551",
+  horizontal: "\u2550",
+  beginText: "\u2561",
+  endText: "\u255E",
+};
+
+const boxed = (str: string): string =>
+  [...str]
+    .map((char) => `${char}${combiningOverline}${combiningUnderline}`)
+    .join("");
+
+class ConsoleViewport {
+  #box = doubleLineBox;
+  #text: LogLine[] = [];
+  #maxChars: number;
+  #horizontalBorder: string;
+  #enabled: boolean;
+
+  constructor(text: LogLine[], enabled: boolean) {
+    this.#text = text;
+
+    // TODO: Use segmenter for better visual spacing
+    this.#maxChars = Math.max(0, ...text.map((line) => line.message.length));
+    this.#enabled = enabled && this.#maxChars > 0;
+    this.#horizontalBorder = this.#box.horizontal.repeat(this.#maxChars + 2);
+  }
+
+  getLine(row: number): string {
+    if (!this.#enabled) return "";
+    return `${this.#box.vertical} ${(
+      this.#text[this.#text.length - row - 1]?.message ?? ""
+    ).padEnd(this.#maxChars)} ${this.#box.vertical}`;
+  }
+
+  getTopBorder(): string {
+    if (!this.#enabled) return "";
+    return `${this.#box.corners.topLeft}${this.#getTopBorderLine()}${
+      this.#box.corners.topRight
+    }`;
+  }
+
+  #getTopBorderLine() {
+    let title = "console";
+    if (this.#maxChars < title.length + 2) return this.#horizontalBorder;
+    let padChars = (this.#maxChars - title.length) / 2;
+    return `${this.#box.horizontal.repeat(Math.floor(padChars))}${
+      this.#box.beginText
+    }${boxed(title)}${this.#box.endText}${this.#box.horizontal.repeat(
+      Math.ceil(padChars)
+    )}`;
+  }
+
+  getBottomBorder(): string {
+    if (!this.#enabled) return "";
+    return `${this.#box.corners.bottomLeft}${this.#horizontalBorder}${
+      this.#box.corners.bottomRight
+    }`;
+  }
+}
+
+export default class Console {
+  #text: LogLine[] = [];
+
+  constructor(private enabled: boolean) {}
+
+  #makeLogger =
+    (verbosity: Verbosity) =>
+    (...args: any[]) => {
+      this.#text.push({
+        time: new Date(),
+        message: args.map((arg) => String(arg)).join(" "),
+        verbosity,
+      });
+    };
+
+  info = this.#makeLogger("info");
+  debug = this.#makeLogger("debug");
+
+  getViewport(numberOfLines: number) {
+    return new ConsoleViewport(this.#text.slice(-numberOfLines), this.enabled);
+  }
+}

--- a/class/resources/colors.ts
+++ b/class/resources/colors.ts
@@ -1,0 +1,28 @@
+export type ColorCode = `\x1b[${string}m`;
+
+export const colorCodes = {
+  black: "\x1b[30m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  magenta: "\x1b[35m",
+  cyan: "\x1b[36m",
+  white: "\x1b[37m",
+} satisfies Record<string, ColorCode>;
+
+export const bgColorCodes = {
+  //background color
+  black: "\x1b[40m",
+  red: "\x1b[41m",
+  green: "\x1b[42m",
+  yellow: "\x1b[43m",
+  blue: "\x1b[44m",
+  magenta: "\x1b[45m",
+  cyan: "\x1b[46m",
+  white: "\x1b[47m",
+} satisfies Record<Color, ColorCode>;
+
+export const resetColor: ColorCode = "\x1b[0m";
+
+export type Color = keyof typeof colorCodes;

--- a/class/resources/typography.ts
+++ b/class/resources/typography.ts
@@ -1,0 +1,6 @@
+export const ideographicSpace = "\u3000";
+export type IdeographicSpace = typeof ideographicSpace;
+
+export const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});

--- a/class/resources/typography.ts
+++ b/class/resources/typography.ts
@@ -4,3 +4,30 @@ export type IdeographicSpace = typeof ideographicSpace;
 export const graphemeSegmenter = new Intl.Segmenter(undefined, {
   granularity: "grapheme",
 });
+
+interface Box {
+  corners: {
+    topLeft: string;
+    topRight: string;
+    bottomLeft: string;
+    bottomRight: string;
+  };
+  vertical: string;
+  horizontal: string;
+
+  beginText: string;
+  endText: string;
+}
+
+export const doubleLineBox: Box = {
+  corners: {
+    topLeft: "\u2554",
+    topRight: "\u2557",
+    bottomLeft: "\u255A",
+    bottomRight: "\u255D",
+  },
+  vertical: "\u2551",
+  horizontal: "\u2550",
+  beginText: "\u2561",
+  endText: "\u255E",
+};

--- a/class/screen.ts
+++ b/class/screen.ts
@@ -74,7 +74,7 @@ export default class Screen<Piece extends string>
   private quitMessage: string = "";
 
   public debugConsole: Console = new Console(
-    !!(process.env.ENABLE_CONSOLE ?? true)
+    Console.getVerbosity(process.env.CONSOLE_VERBOSITY)
   );
 
   constructor(numRows: number, numCols: number, gridLines: boolean) {
@@ -261,7 +261,7 @@ export default class Screen<Piece extends string>
     keypress(process.stdin);
 
     process.stdin.on("keypress", (ch, key) => {
-      this.debugConsole.info(`pressed ${key.name}`);
+      this.debugConsole.logDebug(`pressed ${key.name}`);
       if (!key) {
         console.log("Warning: Unknown keypress");
       } else if (!this.commands.hasOwnProperty(key.name)) {

--- a/class/screen.ts
+++ b/class/screen.ts
@@ -1,37 +1,23 @@
+import {
+  Color,
+  ColorCode,
+  bgColorCodes,
+  colorCodes,
+  resetColor,
+} from "./resources/colors";
 import Command from "./command";
 import Console from "./console";
+import {
+  graphemeSegmenter,
+  ideographicSpace,
+  IdeographicSpace,
+} from "./resources/typography";
 
 const keypress = require("keypress");
 
-type ColorCode = `\x1b[${string}m`;
 export type GridSpace<Piece extends string, EmptySpace extends string> =
   | Piece
   | EmptySpace;
-
-const colorCodes = {
-  black: "\x1b[30m",
-  red: "\x1b[31m",
-  green: "\x1b[32m",
-  yellow: "\x1b[33m",
-  blue: "\x1b[34m",
-  magenta: "\x1b[35m",
-  cyan: "\x1b[36m",
-  white: "\x1b[37m",
-} satisfies Record<string, ColorCode>;
-
-export type Color = keyof typeof colorCodes;
-
-const bgColorCodes = {
-  //background color
-  black: "\x1b[40m",
-  red: "\x1b[41m",
-  green: "\x1b[42m",
-  yellow: "\x1b[43m",
-  blue: "\x1b[44m",
-  cyan: "\x1b[46m",
-  white: "\x1b[47m",
-  magenta: "\x1b[45m",
-} satisfies Record<Color, ColorCode>;
 
 export interface IScreen<Piece extends string, EmptySpace extends string> {
   /** Should be called when the screen is first set up. Initializes event listeners and built-in commands (quit)  */
@@ -55,13 +41,6 @@ export interface IScreen<Piece extends string, EmptySpace extends string> {
   /** Set the message to be displayed on screen with every rerender */
   setMessage(msg: string): void;
 }
-
-const ideographicSpace = "\u3000";
-type IdeographicSpace = typeof ideographicSpace;
-
-const graphemeSegmenter = new Intl.Segmenter(undefined, {
-  granularity: "grapheme",
-});
 
 /**
  * The screen class exposes an API to create grid-based text UIs.
@@ -211,12 +190,12 @@ export default class Screen<Piece extends string>
         let backgroundColor = this.backgroundColors[row][col]
           ? this.backgroundColors[row][col]
           : "";
-        if (!(textColor && backgroundColor)) textColor = "\x1b[0m";
+        if (!(textColor && backgroundColor)) textColor = resetColor;
 
         let vertLine = this.gridLines && col > 0 ? "|" : "";
         rowCopy[
           col
-        ] = `${Screen.defaultBackgroundColor}${vertLine}\x1b[0m${textColor}${backgroundColor}${spacer}${rowCopy[col]}${spacer}\x1b[0m`;
+        ] = `${Screen.defaultBackgroundColor}${vertLine}${resetColor}${textColor}${backgroundColor}${spacer}${rowCopy[col]}${spacer}${resetColor}`;
       }
 
       if (this.gridLines && row > 0) {
@@ -224,7 +203,7 @@ export default class Screen<Piece extends string>
         horizontalGridLine.unshift(
           `${this.borderChar}${Screen.defaultBackgroundColor}`
         );
-        horizontalGridLine.push(`\x1b[0m${this.borderChar}`);
+        horizontalGridLine.push(`${resetColor}${this.borderChar}`);
         console.log(horizontalGridLine.join(""));
       }
 


### PR DESCRIPTION
It's pretty nice! Invoke with the `screen.debugConsole` API. See examples in code.

The `CONSOLE_VERBOSITY` env var can be used to configure which logs show up - if you set it to `info` (the default), it will only show `info` logs. If you set it to `debug`, it will show debug and info logs. Can add more levels as needed.

I got tired towards the end so some of it isn't as clean as it should be 😬